### PR TITLE
Add macOS support; input validation; an example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ build_dir=build/pkg
 dist_dir=build/dist
 
 # Variables that are replaced in build time
-bin_path=/usr/bin
-lib_path=/usr/lib/ansible-bundler
-etc_path=/etc/ansible-bundler
+bin_path=.
+lib_path=../lib/ansible-bundler
+etc_path=../../etc/ansible-bundler
 version=$(shell cat VERSION)
 
 # Package variables
@@ -32,7 +32,13 @@ package:
 	cp -r app/bin $(build_dir)/usr
 	cp -r app/etc $(build_dir)/etc/ansible-bundler
 	cp -r app/lib $(build_dir)/usr/lib/ansible-bundler
-	sed -i'' \
+	UNAME=$$(uname); \
+	if [ "$$UNAME" == 'Darwin' ]; then \
+		SED_BINARY=$$(which gsed); \
+	else \
+		SED_BINARY=$$(which sed); \
+	fi; \
+	$$SED_BINARY -i'' \
 		-e 's#LIB_PATH=.*#LIB_PATH=$(lib_path)#' \
 		-e 's#ETC_PATH=.*#ETC_PATH=$(etc_path)#' \
 		-e 's#VERSION=.*#VERSION=$(version)#' \

--- a/README.md
+++ b/README.md
@@ -128,3 +128,19 @@ Please make sure to update tests as appropriate. For more information, please re
 
 This project is licensed under the BSD 3-Clause License - see the [LICENSE.md](LICENSE.md) file for
 details.
+
+## Example
+
+Before reading this, be sure to follow the instructions  
+above to build the package.  
+
+```shell
+# Starting from the root of this repository, run this command:
+cd build/pkg/usr/bin 
+
+# Employ the basic playbook example
+./bundle-playbook -f ../../../../examples/basic.yaml
+
+# Run the playbook
+../../../../examples/basic.run -e example=VALUE
+```

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ available](https://aur.archlinux.org/packages/ansible-bundler/) if you're using 
 You can also install it using homebrew if you're on macOS:
 
 ```shell
-$ brew install kriansa/tap/ansible-bundler
-
+# Install dependency
+brew install gnu-sed
+# Install ansible-bundler
+brew install kriansa/tap/ansible-bundler
 ```
 
 If your distro is not compatible with the prebuilt packages, please refer to [Building](#building)
@@ -138,6 +140,27 @@ cd build/pkg/usr/bin
 
 # Run the playbook
 ../../../../examples/basic.run -e example=VALUE
+```
+
+### Installing brew formula locally
+
+```shell
+brew install --build-from-source ./ansible-bundler.rb
+```
+
+Ignore these errors and warning from the output:
+
+```shell
+Error: Failed to load cask: ./ansible-bundler.rb
+Cask 'ansible-bundler' is unreadable: wrong constant name #<Class:0x00007fdea4148ef0>
+Warning: Treating ./ansible-bundler.rb as a formula.
+Warning: building from source is not supported!
+```
+
+Test installed formula:
+
+```shell
+bundle-playbook -f /usr/local/opt/ansible-bundler/share/ansible-bundler/examples -o basic
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ Ansible Bundler makes these steps easier by having a single binary that takes ca
 Ansible on the host and executing the playbook without having to do anything globally (such as
 installing ansible). You can simply pull the playbook binary and execute it right away.
 
+## Installation
+
+Currently you can download and install it using the pre-built packages that are available in RPM and
+DEB formats on [Github releases](https://github.com/kriansa/ansible-bundler/releases). They should
+work on most RHEL-based distros (CentOS, Fedora, Amazon Linux, etc) as well as on Debian-based
+distros (Ubuntu, Mint, etc). There's also a [AUR
+available](https://aur.archlinux.org/packages/ansible-bundler/) if you're using Arch.
+
+You can also install it using homebrew if you're on macOS:
+
+```shell
+$ brew install kriansa/tap/ansible-bundler
+
+```
+
+If your distro is not compatible with the prebuilt packages, please refer to [Building](#building)
+below.
+
 ## Usage
 
 ##### Generate a new self-contained playbook:
@@ -78,18 +96,13 @@ can currently use:
                   the packaged playbook.
 ```
 
-## Installation
+---
 
-Currently you can download and install it using the pre-built packages that are available in RPM and
-DEB formats on [Github releases](https://github.com/kriansa/ansible-bundler/releases). They should
-work on most RHEL-based distros (CentOS, Fedora, Amazon Linux, etc) as well as on Debian-based
-distros (Ubuntu, Mint, etc). There's also a [AUR
-available](https://aur.archlinux.org/packages/ansible-bundler/) if you're using Arch.
+## Development
 
-If your distro is not compatible with the prebuilt packages, please refer to [Building](#building)
-below.
+This section should be read by anyone planning to contribute to this project.
 
-## Building
+### Building
 
 You will need Docker installed on your machine. When you have it installed, you can proceed
 installing the dependencies with:
@@ -108,13 +121,24 @@ $ make
 
 > The output will be at `build/pkg`
 
-In fact, we offer support for building `deb` and `rpm` artifacts out of the box:
+Additionally, we offer support for building `deb` and `rpm` artifacts out of the box:
 
 ```shell
 $ make deb rpm
 ```
 
-> The output will be at `build/dist`
+### Running local build
+
+```shell
+# Starting from the root of this repository, run this command:
+cd build/pkg/usr/bin 
+
+# Employ the basic playbook example
+./bundle-playbook -f ../../../../examples/basic.yaml
+
+# Run the playbook
+../../../../examples/basic.run -e example=VALUE
+```
 
 ## Contributing
 
@@ -128,19 +152,3 @@ Please make sure to update tests as appropriate. For more information, please re
 
 This project is licensed under the BSD 3-Clause License - see the [LICENSE.md](LICENSE.md) file for
 details.
-
-## Example
-
-Before reading this, be sure to follow the instructions  
-above to build the package.  
-
-```shell
-# Starting from the root of this repository, run this command:
-cd build/pkg/usr/bin 
-
-# Employ the basic playbook example
-./bundle-playbook -f ../../../../examples/basic.yaml
-
-# Run the playbook
-../../../../examples/basic.run -e example=VALUE
-```

--- a/ansible-bundler.rb
+++ b/ansible-bundler.rb
@@ -1,0 +1,40 @@
+class AnsibleBundler < Formula
+    include Language::Python::Virtualenv
+  
+    desc "Ansible Bundler provides the ability to bundle and execute an Ansible Playbook as a binary."
+    homepage "https://github.com/cowdogmoo/ansible-bundler"
+    url "https://github.com/cowdogmoo/ansible-bundler/archive/refs/heads/master.tar.gz"
+    version "2023.04.26"
+    sha256 "742f9b70a400a45790bf90e7901635f2686ec339a906edfd8d4fc6afe1e109bb"
+    license "BSD 3"
+    depends_on "python@3.11"
+  
+    def install
+      bin.install "app/bin/bundle-playbook"
+      lib.install Dir["app/lib/*"]
+      (etc/"ansible-bundler").install "app/etc/ansible.cfg"
+
+      # Update the bundle-playbook script to use the correct path for the ansible.cfg file and use the correct shell (zsh by default in macOS)
+      inreplace "#{bin}/bundle-playbook", /^#!\/usr\/bin\/env bash/, "#!/usr/bin/env zsh"
+      # Create the necessary directories and copy the examples
+      pkgshare.install "examples"
+    end
+  
+    def caveats
+      <<~EOS
+        Example usage:
+
+        # Employ the basic playbook example
+        bundle-playbook -f #{pkgshare}/examples -o basic
+        
+        # Run the basic playbook binary and provide an input for the example variable.
+        ./basic -e example=VALUE
+      EOS
+    end
+
+    test do
+      # Test your project here
+      system "#{bin}/bundle-playbook", "--version"
+    end
+  end
+  

--- a/app/bin/bundle-playbook
+++ b/app/bin/bundle-playbook
@@ -194,20 +194,20 @@ copy_playbook() {
 	shift 4; local extra_deps=("${@}")
 
 	echo "Adding playbook..."
-	cp -L --preserve=timestamps "$playbook_file" "$tmpdir/playbook.yml"
+	cp -L -p "$playbook_file" "$tmpdir/playbook.yml"
 	if [ -d "$playbook_path/roles" ]; then
 		echo "Adding roles..."
-		cp -Lr --preserve=timestamps "$playbook_path/roles" "$tmpdir"
+		cp -Lrp "$playbook_path/roles" "$tmpdir"
 	fi
 
 	if [ -n "$requirements_file" ]; then
 		echo "Adding requirements..."
-		cp -L --preserve=timestamps "$requirements_file" "$tmpdir/requirements.yml"
+		cp -L -p "$requirements_file" "$tmpdir/requirements.yml"
 	fi
 
 	if [ -n "$vars_file" ]; then
 		echo "Adding vars..."
-		cp -L --preserve=timestamps "$vars_file" "$tmpdir/vars.yml"
+		cp -L -p "$vars_file" "$tmpdir/vars.yml"
 	fi
 
 	if [ ${#extra_deps[@]} -gt 0 ]; then
@@ -218,7 +218,7 @@ copy_playbook() {
 	fi
 
 	echo "Adding ansible config..."
-	cp -L --preserve=timestamps "$ETC_PATH/ansible.cfg" "$tmpdir"
+	cp -L -p "$ETC_PATH/ansible.cfg" "$tmpdir"
 }
 
 add_python_requirements() {
@@ -290,20 +290,34 @@ install_roles() {
 
 add_entrypoint() {
 	echo "Adding entrypoint..."
-	cp -L --preserve=timestamps "$LIB_PATH/run-playbook.sh" "$tmpdir"
-	chmod 0755 "$tmpdir/run-playbook.sh"
+    if [ -e "$LIB_PATH/run-playbook.sh" ]; then
+        cp -L -p "$LIB_PATH/run-playbook.sh" "$tmpdir"
+        chmod 0755 "$tmpdir/run-playbook.sh"
+    else
+        echo "File not found: $LIB_PATH/run-playbook.sh"
+    fi
 }
 
 compress_output() {
-	local output_file=$1
+    local output_file=$1
 
-	echo "Packaging files to the output..."
+    echo "Packaging files to the output..."
 
-	# First add the header to the final script
-	cat "$LIB_PATH/bin-header.sh" > "$output_file"
+    # First add the header to the final script
+    if [ -e "$LIB_PATH/bin-header.sh" ]; then
+        cat "$LIB_PATH/bin-header.sh" > "$output_file"
+    else
+        echo "File not found: $LIB_PATH/bin-header.sh"
+    fi
 
+	SED_BINARY=''
 	# Do some build-time metadata insertion
-	sed -i'' \
+	if [[ "$(uname)" == 'Darwin' ]]; then 
+		SED_BINARY=`which gsed`
+	else 
+		SED_BINARY=`which sed`
+	fi
+	$SED_BINARY -i'' \
 		-e "s/UNCOMPRESS_SKIP=.*/UNCOMPRESS_SKIP=$(( $(wc -l < "$output_file") + 1 ))/" \
 		-e "s/\$VERSION/$VERSION/g" \
 		"$output_file"

--- a/app/bin/bundle-playbook
+++ b/app/bin/bundle-playbook
@@ -65,78 +65,78 @@ set_config_vars() {
 validate_parameters() {
 	while [ $# -gt 0 ]; do
 		case "$1" in
-			-f|--playbook-file)
-				playbook_file=$2
-				shift 2
-				;;
-			--playbook-file=*)
-				playbook_file=${1#*=}
-				shift 1
-				;;
+		-f | --playbook-file)
+			playbook_file=$2
+			shift 2
+			;;
+		--playbook-file=*)
+			playbook_file=${1#*=}
+			shift 1
+			;;
 
-			-r|--requirements-file)
-				requirements_file=$2
-				shift 2
-				;;
-			--requirements-file=*)
-				requirements_file=${1#*=}
-				shift 1
-				;;
+		-r | --requirements-file)
+			requirements_file=$2
+			shift 2
+			;;
+		--requirements-file=*)
+			requirements_file=${1#*=}
+			shift 1
+			;;
 
-			-v|--vars-file)
-				vars_file=$2
-				shift 2
-				;;
-			--vars-file=*)
-				vars_file=${1#*=}
-				shift 1
-				;;
+		-v | --vars-file)
+			vars_file=$2
+			shift 2
+			;;
+		--vars-file=*)
+			vars_file=${1#*=}
+			shift 1
+			;;
 
-			-d|--extra-deps)
-				extra_deps+=("$2")
-				shift 2
-				;;
-			--extra-deps=*)
-				extra_deps+=("${1#*=}")
-				shift 1
-				;;
+		-d | --extra-deps)
+			extra_deps+=("$2")
+			shift 2
+			;;
+		--extra-deps=*)
+			extra_deps+=("${1#*=}")
+			shift 1
+			;;
 
-			-a|--ansible-version)
-				ansible_version=$2
-				shift 2
-				;;
-			--ansible-version=*)
-				ansible_version=${1#*=}
-				shift 1
-				;;
+		-a | --ansible-version)
+			ansible_version=$2
+			shift 2
+			;;
+		--ansible-version=*)
+			ansible_version=${1#*=}
+			shift 1
+			;;
 
-			-p|--python-package)
-				extra_python_deps+=("$2")
-				shift 2
-				;;
-			--python-package=*)
-				extra_python_deps+=("${1#*=}")
-				shift 1
-				;;
+		-p | --python-package)
+			extra_python_deps+=("$2")
+			shift 2
+			;;
+		--python-package=*)
+			extra_python_deps+=("${1#*=}")
+			shift 1
+			;;
 
-			-o|--output)
-				output_file=$2
-				shift 2
-				;;
-			--output=*)
-				output_file=${1#*=}
-				shift 1
-				;;
+		-o | --output)
+			output_file=$2
+			shift 2
+			;;
+		--output=*)
+			output_file=${1#*=}
+			shift 1
+			;;
 
-			-h|--help)
-				help
-				exit
-				;;
+		-h | --help)
+			help
+			exit
+			;;
 
-			*)
-				error "Parameter $1 is invalid. Please use --help to see all available options."
-				exit 1
-				;;
+		*)
+			error "Parameter $1 is invalid. Please use --help to see all available options."
+			exit 1
+			;;
 		esac
 	done
 
@@ -191,7 +191,8 @@ copy_playbook() {
 	local playbook_file=$2
 	local requirements_file=$3
 	local vars_file=$4
-	shift 4; local extra_deps=("${@}")
+	shift 4
+	local extra_deps=("${@}")
 
 	echo "Adding playbook..."
 	cp -Lp "$playbook_file" "$tmpdir/playbook.yml"
@@ -223,17 +224,18 @@ copy_playbook() {
 
 add_python_requirements() {
 	local ansible_version=$1
-	shift; local extra_packages=("${@}")
+	shift
+	local extra_packages=("${@}")
 
 	if [ -n "$ansible_version" ]; then
-		echo "ansible==$ansible_version" > "$tmpdir/requirements.txt"
+		echo "ansible==$ansible_version" >"$tmpdir/requirements.txt"
 	else
-		echo "ansible" > "$tmpdir/requirements.txt"
+		echo "ansible" >"$tmpdir/requirements.txt"
 	fi
 
 	# Add extra python packages
 	for package in "${extra_packages[@]}"; do
-		echo "$package" >> "$tmpdir/requirements.txt"
+		echo "$package" >>"$tmpdir/requirements.txt"
 	done
 }
 
@@ -249,7 +251,7 @@ install_collections() {
 	# Prevent collections installs if there's no such key at the requirements.yml file
 	# This will allow ansible-bundler to be backwards compatible with ansible < 2.9 when galaxy only
 	# packaged roles and not collections.
-	grep "collections:" "$tmpdir/requirements.yml" > /dev/null 2>&1 || return
+	grep "collections:" "$tmpdir/requirements.yml" >/dev/null 2>&1 || return
 
 	echo "Installing playbook collection dependencies..."
 
@@ -259,7 +261,8 @@ install_collections() {
 
 	ansible-galaxy collection install --ignore-errors --force-with-deps --verbose \
 		--requirements-file="$tmpdir/requirements.yml" \
-		--collections-path="$tmpdir/galaxy-collections"; local status=$?
+		--collections-path="$tmpdir/galaxy-collections"
+	local status=$?
 
 	if [ $status -ne 0 ]; then
 		echo "Collection dependencies installation failed."
@@ -276,11 +279,12 @@ install_roles() {
 
 	ansible-galaxy role install --ignore-errors --force-with-deps --verbose \
 		--role-file="$tmpdir/requirements.yml" \
-		--roles-path="$tmpdir/galaxy-roles"; local status=$?
+		--roles-path="$tmpdir/galaxy-roles"
+	local status=$?
 
 	# Remove galaxy install metadata, which is dynamically generated, but non-deterministic and
 	# prevents our build output to be idempotent
-	rm "$tmpdir"/galaxy-roles/*/*/.galaxy_install_info 2> /dev/null
+	rm "$tmpdir"/galaxy-roles/*/*/.galaxy_install_info 2>/dev/null
 
 	if [ $status -ne 0 ]; then
 		echo "Role dependencies installation failed."
@@ -290,35 +294,35 @@ install_roles() {
 
 add_entrypoint() {
 	echo "Adding entrypoint..."
-    if [ -e "$LIB_PATH/run-playbook.sh" ]; then
-        cp -Lp "$LIB_PATH/run-playbook.sh" "$tmpdir"
-        chmod 0755 "$tmpdir/run-playbook.sh"
-    else
-        echo "File not found: $LIB_PATH/run-playbook.sh"
-    fi
+	if [ -e "$LIB_PATH/run-playbook.sh" ]; then
+		cp -Lp "$LIB_PATH/run-playbook.sh" "$tmpdir"
+		chmod 0755 "$tmpdir/run-playbook.sh"
+	else
+		echo "File not found: $LIB_PATH/run-playbook.sh"
+	fi
 }
 
 compress_output() {
-    local output_file=$1
+	local output_file=$1
 
-    echo "Packaging files to the output..."
+	echo "Packaging files to the output..."
 
-    # First add the header to the final script
-    if [ -e "$LIB_PATH/bin-header.sh" ]; then
-        cat "$LIB_PATH/bin-header.sh" > "$output_file"
-    else
-        echo "File not found: $LIB_PATH/bin-header.sh"
-    fi
+	# First add the header to the final script
+	if [ -e "$LIB_PATH/bin-header.sh" ]; then
+		cat "$LIB_PATH/bin-header.sh" >"$output_file"
+	else
+		echo "File not found: $LIB_PATH/bin-header.sh"
+	fi
 
 	SED_BINARY=''
 	# Do some build-time metadata insertion
-	if [[ "$(uname)" == 'Darwin' ]]; then 
-		SED_BINARY=`which gsed`
-	else 
-		SED_BINARY=`which sed`
+	if [[ "$(uname)" == 'Darwin' ]]; then
+		SED_BINARY=$(which gsed)
+	else
+		SED_BINARY=$(which sed)
 	fi
 	$SED_BINARY -i'' \
-		-e "s/UNCOMPRESS_SKIP=.*/UNCOMPRESS_SKIP=$(( $(wc -l < "$output_file") + 1 ))/" \
+		-e "s/UNCOMPRESS_SKIP=.*/UNCOMPRESS_SKIP=$(($(wc -l <"$output_file") + 1))/" \
 		-e "s/\$VERSION/$VERSION/g" \
 		"$output_file"
 
@@ -327,7 +331,7 @@ compress_output() {
 	find "$tmpdir" -exec touch -d "1970-01-01T00:00:00Z" {} +
 
 	# Then add the tar.gz binary content to it
-	tar czC "$tmpdir" . >> "$output_file"
+	tar czC "$tmpdir" . >>"$output_file"
 
 	# Lastly, make it executable
 	chmod +x "$output_file"

--- a/app/bin/bundle-playbook
+++ b/app/bin/bundle-playbook
@@ -194,7 +194,7 @@ copy_playbook() {
 	shift 4; local extra_deps=("${@}")
 
 	echo "Adding playbook..."
-	cp -L -p "$playbook_file" "$tmpdir/playbook.yml"
+	cp -Lp "$playbook_file" "$tmpdir/playbook.yml"
 	if [ -d "$playbook_path/roles" ]; then
 		echo "Adding roles..."
 		cp -Lrp "$playbook_path/roles" "$tmpdir"
@@ -202,12 +202,12 @@ copy_playbook() {
 
 	if [ -n "$requirements_file" ]; then
 		echo "Adding requirements..."
-		cp -L -p "$requirements_file" "$tmpdir/requirements.yml"
+		cp -Lp "$requirements_file" "$tmpdir/requirements.yml"
 	fi
 
 	if [ -n "$vars_file" ]; then
 		echo "Adding vars..."
-		cp -L -p "$vars_file" "$tmpdir/vars.yml"
+		cp -Lp "$vars_file" "$tmpdir/vars.yml"
 	fi
 
 	if [ ${#extra_deps[@]} -gt 0 ]; then
@@ -218,7 +218,7 @@ copy_playbook() {
 	fi
 
 	echo "Adding ansible config..."
-	cp -L -p "$ETC_PATH/ansible.cfg" "$tmpdir"
+	cp -Lp "$ETC_PATH/ansible.cfg" "$tmpdir"
 }
 
 add_python_requirements() {
@@ -291,7 +291,7 @@ install_roles() {
 add_entrypoint() {
 	echo "Adding entrypoint..."
     if [ -e "$LIB_PATH/run-playbook.sh" ]; then
-        cp -L -p "$LIB_PATH/run-playbook.sh" "$tmpdir"
+        cp -Lp "$LIB_PATH/run-playbook.sh" "$tmpdir"
         chmod 0755 "$tmpdir/run-playbook.sh"
     else
         echo "File not found: $LIB_PATH/run-playbook.sh"

--- a/app/lib/bin-header.sh
+++ b/app/lib/bin-header.sh
@@ -69,7 +69,13 @@ main() {
 
 # Escapes any double quotes with backslashes
 escape_quotes() {
-	printf '%s' "$1" | sed -E 's/"/\\"/g'
+	SED_BINARY=''
+	if [[ "$(uname)" == 'Darwin' ]]; then 
+		SED_BINARY=`which gsed`
+	else 
+		SED_BINARY=`which sed`
+	fi
+	printf '%s' "$1" | $SED_BINARY -E 's/"/\\"/g'
 }
 
 invalid_parameter_error() {

--- a/app/lib/bin-header.sh
+++ b/app/lib/bin-header.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This is a packaged ansible playbook file using Ansible Bundler v$VERSION.
 # You can run this with --debug to show more information about the process.

--- a/app/lib/bin-header.sh
+++ b/app/lib/bin-header.sh
@@ -29,27 +29,27 @@ main() {
 
 	while [ $# -gt 0 ]; do
 		case "$1" in
-			# Show debug logs
-			--debug) DEBUG=1 && shift ;;
+		# Show debug logs
+		--debug) DEBUG=1 && shift ;;
 
-			# Keep extracted files into the tempfolder. Useful for debugging
-			--keep-temp) KEEP_TEMP=1 && shift ;;
+		# Keep extracted files into the tempfolder. Useful for debugging
+		--keep-temp) KEEP_TEMP=1 && shift ;;
 
-			# Passthrough directly to the run-playbook.sh
-			-e|--extra-vars)
-				args="$args --extra-vars \"$(escape_quotes "$2")\""
-				shift 2
-				;;
-			--extra-vars=*)
-				args="$args --extra-vars \"$(escape_quotes "${1#*=}")\""
-				shift 1
-				;;
+		# Passthrough directly to the run-playbook.sh
+		-e | --extra-vars)
+			args="$args --extra-vars \"$(escape_quotes "$2")\""
+			shift 2
+			;;
+		--extra-vars=*)
+			args="$args --extra-vars \"$(escape_quotes "${1#*=}")\""
+			shift 1
+			;;
 
-			# Show help message
-			--help|-h) help && exit ;;
+		# Show help message
+		--help | -h) help && exit ;;
 
-			# Ignore all other parameters
-			*) invalid_parameter_error "$1" && exit 1 ;;
+		# Ignore all other parameters
+		*) invalid_parameter_error "$1" && exit 1 ;;
 		esac
 	done
 
@@ -70,10 +70,10 @@ main() {
 # Escapes any double quotes with backslashes
 escape_quotes() {
 	SED_BINARY=''
-	if [[ "$(uname)" == 'Darwin' ]]; then 
-		SED_BINARY=`which gsed`
-	else 
-		SED_BINARY=`which sed`
+	if [[ "$(uname)" == 'Darwin' ]]; then
+		SED_BINARY=$(which gsed)
+	else
+		SED_BINARY=$(which sed)
 	fi
 	printf '%s' "$1" | $SED_BINARY -E 's/"/\\"/g'
 }
@@ -101,7 +101,7 @@ extract_content() {
 
 	# Ensure we are compatible with both bsd and GNU tar
 	extra_params=""
-	tar --version | grep 'GNU tar' > /dev/null 2>&1 && extra_params="--warning=no-timestamp"
+	tar --version | grep 'GNU tar' >/dev/null 2>&1 && extra_params="--warning=no-timestamp"
 
 	tail -n +$UNCOMPRESS_SKIP "$0" | tar xzC "$tmpdir" $extra_params
 }

--- a/app/lib/run-playbook.sh
+++ b/app/lib/run-playbook.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This is the entry point for the playbook bundle. It has a hard dependency on Python. It will try
 # to look for an already existing installation of Ansible, and will try to install it if not found.
@@ -11,7 +11,11 @@ main() {
 	export BASEDIR=${BASEDIR:-.}
 
 	# Ensure we have HOME defined, otherwise set it manually
-	test -z "$HOME" && export HOME; HOME="$(getent passwd "$(id -un)" | cut -d: -f6)"
+	if [[ "$(uname)" == 'Darwin' ]]; then
+ 	   test -z "$HOME" && export HOME; HOME="$(dscl . -read /Users/$(id -un) NFSHomeDirectory | awk -F': ' '{print $2}')"
+	else
+  	  test -z "$HOME" && export HOME; HOME="$(getent passwd "$(id -un)" | cut -d: -f6)"
+	fi
 
 	export PIP_ROOT_PATH; PIP_ROOT_PATH="$(realpath "${BASEDIR}/python-deps")"
 	export PATH="${PIP_ROOT_PATH}/usr/bin:${PIP_ROOT_PATH}${HOME}/.local/bin:${PATH}"

--- a/app/lib/run-playbook.sh
+++ b/app/lib/run-playbook.sh
@@ -12,37 +12,41 @@ main() {
 
 	# Ensure we have HOME defined, otherwise set it manually
 	if [[ "$(uname)" == 'Darwin' ]]; then
- 	   test -z "$HOME" && export HOME; HOME="$(dscl . -read /Users/$(id -un) NFSHomeDirectory | awk -F': ' '{print $2}')"
+		test -z "$HOME" && export HOME
+		HOME="$(dscl . -read /Users/$(id -un) NFSHomeDirectory | awk -F': ' '{print $2}')"
 	else
-  	  test -z "$HOME" && export HOME; HOME="$(getent passwd "$(id -un)" | cut -d: -f6)"
+		test -z "$HOME" && export HOME
+		HOME="$(getent passwd "$(id -un)" | cut -d: -f6)"
 	fi
 
-	export PIP_ROOT_PATH; PIP_ROOT_PATH="$(realpath "${BASEDIR}/python-deps")"
+	export PIP_ROOT_PATH
+	PIP_ROOT_PATH="$(realpath "${BASEDIR}/python-deps")"
 	export PATH="${PIP_ROOT_PATH}/usr/bin:${PIP_ROOT_PATH}${HOME}/.local/bin:${PATH}"
 
 	ensure_python_is_installed
 	install_ansible
 
 	# Export the right paths so we can run python binaries installed on non-default paths
-	export PYTHONPATH; PYTHONPATH=$(find "$PIP_ROOT_PATH" -type d -name site-packages | head -1)
+	export PYTHONPATH
+	PYTHONPATH=$(find "$PIP_ROOT_PATH" -type d -name site-packages | head -1)
 
 	run_playbook "$@"
 }
 
 ensure_python_is_installed() {
-	if ! command -v python > /dev/null 2>&1 && ! command -v python3 > /dev/null 2>&1; then
+	if ! command -v python >/dev/null 2>&1 && ! command -v python3 >/dev/null 2>&1; then
 		echo "Error: Python is not installed!"
 		exit 1
 	fi
 
-	if ! command -v pip > /dev/null 2>&1 && ! command -v pip3 > /dev/null 2>&1; then
+	if ! command -v pip >/dev/null 2>&1 && ! command -v pip3 >/dev/null 2>&1; then
 		echo "Error: Python pip is not found!"
 		exit 1
 	fi
 }
 
 pip() {
-	if command -v pip3 > /dev/null 2>&1; then
+	if command -v pip3 >/dev/null 2>&1; then
 		command pip3 "$@"
 	else
 		command pip "$@"
@@ -63,7 +67,8 @@ install_ansible() {
 	# memory for the cache, which causes a MemoryError.
 	# See: https://stackoverflow.com/questions/29466663/memory-error-while-using-pip-install-matplotlib
 	pip install --requirement="$BASEDIR/requirements.txt" --no-cache-dir \
-		--user --root="$PIP_ROOT_PATH"; status=$?
+		--user --root="$PIP_ROOT_PATH"
+	status=$?
 
 	if [ $status -ne 0 ]; then
 		echo "Error: Python dependencies could not be installed."
@@ -85,15 +90,15 @@ run_playbook() {
 	# Then add runtime extra-vars, if passed
 	while [ $# -gt 0 ]; do
 		case "$1" in
-			-e|--extra-vars)
-				extra_params="$extra_params --extra-vars \"$(escape_quotes "$2")\""
-				shift 2
-				;;
-			--extra-vars=*)
-				extra_params="$extra_params --extra-vars \"$(escape_quotes "${1#*=}")\""
-				shift 1
-				;;
-			*) shift ;;
+		-e | --extra-vars)
+			extra_params="$extra_params --extra-vars \"$(escape_quotes "$2")\""
+			shift 2
+			;;
+		--extra-vars=*)
+			extra_params="$extra_params --extra-vars \"$(escape_quotes "${1#*=}")\""
+			shift 1
+			;;
+		*) shift ;;
 		esac
 	done
 

--- a/app/lib/run-playbook.sh
+++ b/app/lib/run-playbook.sh
@@ -12,11 +12,9 @@ main() {
 
 	# Ensure we have HOME defined, otherwise set it manually
 	if [[ "$(uname)" == 'Darwin' ]]; then
-		test -z "$HOME" && export HOME
-		HOME="$(dscl . -read /Users/$(id -un) NFSHomeDirectory | awk -F': ' '{print $2}')"
+		test -z "$HOME" && export HOME; HOME="$(dscl . -read /Users/$(id -un) NFSHomeDirectory | awk -F': ' '{print $2}')"
 	else
-		test -z "$HOME" && export HOME
-		HOME="$(getent passwd "$(id -un)" | cut -d: -f6)"
+		test -z "$HOME" && export HOME; HOME="/Users/$(id -un)"
 	fi
 
 	export PIP_ROOT_PATH

--- a/app/lib/run-playbook.sh
+++ b/app/lib/run-playbook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This is the entry point for the playbook bundle. It has a hard dependency on Python. It will try
 # to look for an already existing installation of Ansible, and will try to install it if not found.

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -9,4 +9,4 @@
 
     - name: Print extra variable 'example'
       debug:
-        msg: "Example value is {{ example }}"
+        msg: "Extra variable 'example' value: '{{ example | default('Not provided') }}'"

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -1,0 +1,12 @@
+---
+
+- hosts: all
+
+  tasks:
+    - name: basic-example
+      debug:
+        msg: You are running a basic example
+
+    - name: Print extra variable 'example'
+      debug:
+        msg: "Example value is {{ example }}"


### PR DESCRIPTION
This pull request contains the following:

- The program now works on macOS
- Included brew formulae and instructions to install
  - You will want to change the values in the rb file to match your release, sha, etc.
- There is input validation in place to stop the program from running when something isn't working
- Added missing input validation to ansible example
- Changed the `Makefile` values to relative paths from the build directory
- Created an example and provided documentation in the README 